### PR TITLE
Fix editorconfig typo and normalize markdown headings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,7 +24,7 @@ trim_trailing_whitespace = false
 indent_style = space
 indent_size = 2
 
-[*.{s,mjs,cjs,jsx,ts,mts,cts,tsx}]
+[*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}]
 indent_style = space
 indent_size = 2
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,4 +6,7 @@
   "[typescript]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
 }

--- a/_posts/2021-09-29-alt-docker-for-mac.md
+++ b/_posts/2021-09-29-alt-docker-for-mac.md
@@ -4,25 +4,25 @@ date: "2021-09-29"
 description: "Docker for Macの代替手段としてminikubeを使ってみた感想"
 ---
 
-# TL;DR
+## TL;DR
 
 おとなしくDocker for Macを使いましょう。
 
-# 背景
+## 背景
 
 Docker社に対してお金払いたくないわけではなく、興味本位で代替手段を試した。
 
-# 試したもの
+## 試したもの
 
 - minikube
   - VirtualBox
   - HyperKit
 
-## minikubeの問題
+### minikubeの問題
 
 minikubeの問題というかk8s的な問題かもしれないけど、minikube startするたびにDOCKER_HOSTのIPアドレスが変わる(可能性がある)関係で、docker compose upしたあとに適当にlocalhostで開くみたいなことができない。ただし、DriverにVirtualBoxを使うとVirtualBox側の設定でPort Fowardingができる。手動で設定することにはなるがある程度は楽になる。
 
-## VirtualBoxの問題
+### VirtualBoxの問題
 
 DriverにVirtualBoxを使う場合、alpine系のイメージを使うとapkでパッケージのインストールをするときにDNS Lookup Errorみたいなのが出てどうしようもない。
 
@@ -36,7 +36,7 @@ docker run --rm -it alpine ping -c5 google.com
 
 VirtualBoxのネットワーク周りの設定をいじればどうにかなる可能性もあるが時間をかけたくないので途中で諦めた。
 
-## HyperKitの問題
+### HyperKitの問題
 
 docker composeなどでローカルのファイルをコンテナにマウントしようとしたが、何故か中身が空っぽになるという問題に遭遇した。
 
@@ -46,6 +46,6 @@ minikube start --mount --mount-string "/Users/$USER/ghq:/Users/$USER/ghq"
 
 このようにminikubeの起動時にあらかじめ全部マウントしておかないといけないっぽい。
 
-# 結論
+## 結論
 
 Docker for Mac、お前だったのか。


### PR DESCRIPTION
## Summary
This PR contains three small fixes to improve the codebase consistency: fixing a typo in the editorconfig file pattern, adding JavaScript formatter configuration for VS Code, and normalizing heading levels in a blog post.

## Changes
- Fixed missing 'j' in JavaScript file pattern in `.editorconfig` 
- Added Biome formatter configuration for JavaScript files in VS Code settings
- Normalized heading levels in the Docker for Mac alternative blog post

## Motivation
These changes were necessary to ensure proper editor configuration for JavaScript files and maintain consistent heading hierarchy in markdown documents.

## Technical Details
- The `.editorconfig` pattern was missing the 'j' making it `*.{s,mjs,cjs,jsx,ts,mts,cts,tsx}` instead of the correct `*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}`
- Added JavaScript formatter configuration to match the existing TypeScript formatter settings
- Changed all H1 (#) headings to H2 (##) and H2 to H3 (###) in the blog post to follow proper document structure

## Impact
- Affected features: Editor configuration and blog post formatting
- Affected files: `.editorconfig`, `.vscode/settings.json`, `_posts/2021-09-29-alt-docker-for-mac.md`
- Breaking changes: No

## Testing
1. Verify JavaScript files now properly use Biome formatter in VS Code
2. Confirm editorconfig rules apply correctly to JavaScript files
3. Check that the blog post renders correctly with updated heading levels

## Checklist
- [x] Code works as expected
- [ ] Tests have been added/updated
- [ ] Documentation has been updated (if necessary)
- [x] Linter and formatter have been run
- [x] Breaking changes are clearly documented

## Additional Notes
These are minor housekeeping changes that improve the development experience and content consistency.