### PR TITLE
add Cloudflare Workers deployment pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare Workers
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: production
+    env:
+      ASTRO_TELEMETRY_DISABLED: "1"
+      EMDASH_RUNTIME: cloudflare
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ".node-version"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build application for Cloudflare
+        env:
+          CF_ACCESS_TEAM_DOMAIN: ${{ secrets.CF_ACCESS_TEAM_DOMAIN }}
+        run: pnpm run build
+
+      - name: Deploy Worker
+        env:
+          # Public repo: keep Cloudflare credentials in GitHub environment secrets.
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: pnpm exec wrangler deploy --config dist/server/wrangler.json

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,7 @@
 import cloudflare from "@astrojs/cloudflare";
 import node from "@astrojs/node";
 import react from "@astrojs/react";
-import { cloudflareCache, d1, r2 } from "@emdash-cms/cloudflare";
+import { access, cloudflareCache, d1, r2 } from "@emdash-cms/cloudflare";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
 import emdash, { local } from "emdash/astro";
@@ -10,6 +10,17 @@ import { DEFAULT_LOCALE, LOCALE_FALLBACK, SUPPORTED_LOCALES } from "./src/lib/i1
 
 const runtime = process.env.EMDASH_RUNTIME ?? "local";
 const isCloudflare = runtime === "cloudflare";
+const accessTeamDomain = process.env.CF_ACCESS_TEAM_DOMAIN;
+const defaultAccessRole = 50;
+const accessDefaultRole = Number(process.env.EMDASH_ACCESS_DEFAULT_ROLE ?? defaultAccessRole);
+
+if (isCloudflare && !accessTeamDomain) {
+  throw new Error("CF_ACCESS_TEAM_DOMAIN is required when EMDASH_RUNTIME=cloudflare.");
+}
+
+if (!Number.isInteger(accessDefaultRole)) {
+  throw new Error("EMDASH_ACCESS_DEFAULT_ROLE must be an integer role level.");
+}
 
 export default defineConfig({
   output: "server",
@@ -43,6 +54,12 @@ export default defineConfig({
         ? {
             database: d1({ binding: "DB", session: "auto" }),
             storage: r2({ binding: "MEDIA" }),
+            auth: access({
+              teamDomain: accessTeamDomain,
+              audienceEnvVar: "CF_ACCESS_AUDIENCE",
+              // Access policy owns the outer allowlist; matching users become EmDash admins by default.
+              defaultRole: accessDefaultRole,
+            }),
           }
         : {
             database: sqlite({ url: "file:./data.db" }),

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,36 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "shuymn-me",
+  "compatibility_date": "2026-04-28",
+  "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+  "observability": {
+    "enabled": true
+  },
+  "vars": {
+    // Public-safe runtime vars live here. Keep API tokens and
+    // CF_CACHE_PURGE_TOKEN in GitHub/Worker secrets, not in this file.
+    "EMDASH_RUNTIME": "cloudflare"
+  },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "shuymn-me",
+      "database_id": "73c1da6e-ee28-4550-bbed-875b976c5d0f"
+    }
+  ],
+  "r2_buckets": [
+    {
+      "binding": "MEDIA",
+      "bucket_name": "shuymn-me-media"
+    }
+  ],
+  "kv_namespaces": [
+    {
+      "binding": "SESSION",
+      "id": "867af78d2c7a47378e5862a5cc7c709f"
+    }
+  ],
+  "images": {
+    "binding": "IMAGES"
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -24,12 +24,15 @@
       "bucket_name": "shuymn-me-media"
     }
   ],
+  // @astrojs/cloudflare defaults Astro sessions to KV with this binding
+  // when no explicit session.driver is configured in astro.config.mjs.
   "kv_namespaces": [
     {
       "binding": "SESSION",
       "id": "867af78d2c7a47378e5862a5cc7c709f"
     }
   ],
+  // @astrojs/cloudflare uses this binding for runtime image transforms.
   "images": {
     "binding": "IMAGES"
   }


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to build and deploy the site to Cloudflare Workers on every push to `main`
- Add `wrangler.jsonc` with D1, R2, KV, and Images bindings for the production Worker
- Wire Cloudflare Access authentication into the EmDash plugin config, with env-var validation for `CF_ACCESS_TEAM_DOMAIN` and `EMDASH_ACCESS_DEFAULT_ROLE`
- Update Biome schema URL to match the already-installed v2.4.13

## Changes

| File | Type | Description |
|------|------|-------------|
| `.github/workflows/deploy.yml` | new | CI/CD pipeline: install → build → `wrangler deploy` |
| `wrangler.jsonc` | new | Worker config with D1/R2/KV/Images bindings |
| `astro.config.mjs` | modified | Import and configure `access()` from `@emdash-cms/cloudflare` |
| `biome.json` | modified | Schema URL bump 2.4.12 → 2.4.13 |

## Test plan

- [ ] Secrets `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`, `CF_ACCESS_TEAM_DOMAIN` are set in the `production` GitHub environment
- [ ] `CF_ACCESS_AUDIENCE` is set as a Worker secret in the Cloudflare dashboard
- [ ] Merge triggers the deploy workflow and the Worker is reachable
- [ ] Admin routes are protected by Cloudflare Access (unauthenticated requests are rejected)
