### PR TITLE
chore(renovate): group EmDash packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>shuymn/github-actions#main"]
+  "extends": ["github>shuymn/github-actions#main"],
+  "packageRules": [
+    {
+      "description": "Group EmDash packages so related releases are upgraded together.",
+      "matchPackageNames": ["emdash", "/^@emdash-cms\\//"],
+      "groupName": "EmDash packages",
+      "groupSlug": "emdash"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- Add `packageRules` to `.github/renovate.json` that groups `emdash` and all `@emdash-cms/*` packages under a single Renovate group (`EmDash packages`)
- Prevents separate PRs for each EmDash package release; related packages are now upgraded together in one PR

## Test plan

- [ ] Verify Renovate config is valid (schema check)
- [ ] Confirm next Renovate run groups EmDash package updates into a single PR