### PR TITLE
EmDashスキルをplugin-forms@0.2.1へ更新、wordpress-plugin-to-emdashスキル追加

### DIFF
--- a/.agents/skills/building-emdash-site/SKILL.md
+++ b/.agents/skills/building-emdash-site/SKILL.md
@@ -2,9 +2,9 @@
 description: Build and customize EmDash CMS sites on Astro. Use when creating pages, defining collections, writing seed files, querying content, rendering Portable Text, setting up menus/taxonomies/widgets, configuring deployment, or any task involving an EmDash-powered Astro site. Assumes basic Astro knowledge but provides all EmDash-specific patterns.
 metadata:
     github-path: skills/building-emdash-site
-    github-ref: refs/tags/@emdash-cms/blocks@0.7.0
+    github-ref: refs/tags/@emdash-cms/plugin-forms@0.2.1
     github-repo: https://github.com/emdash-cms/emdash
-    github-tree-sha: ffdc2a30429240e99f442bc4ae066515c229fae4
+    github-tree-sha: 3750da8003604a48db0db020cf1a3640ee8ac7de
 name: building-emdash-site
 ---
 # Building an EmDash Site
@@ -63,11 +63,7 @@ Read **[references/site-features.md](references/site-features.md)** for site set
 
 ### 5. Create the seed file
 
-Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content. Validate with:
-
-```bash
-npx emdash seed seed/seed.json --validate
-```
+Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content.
 
 ### 6. Run and verify
 
@@ -104,7 +100,7 @@ import {
 } from "emdash";
 
 // Bylines (standalone queries -- usually not needed since entries have bylines attached)
-import { getEntryBylines, getBylinesForEntries, getByline, getBylineBySlug } from "emdash";
+import { getByline, getBylineBySlug } from "emdash";
 
 // UI components
 import {

--- a/.agents/skills/building-emdash-site/references/configuration.md
+++ b/.agents/skills/building-emdash-site/references/configuration.md
@@ -97,7 +97,6 @@ Requires a `wrangler.jsonc` with D1 and R2 bindings:
 		{
 			"binding": "DB",
 			"database_name": "my-site",
-			"database_id": "", // from `wrangler d1 create my-site`
 		},
 	],
 	"r2_buckets": [

--- a/.agents/skills/building-emdash-site/references/schema-and-seed.md
+++ b/.agents/skills/building-emdash-site/references/schema-and-seed.md
@@ -1,6 +1,6 @@
 # Schema and Seed Files
 
-The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's applied on first run or via `npx emdash seed seed/seed.json`.
+The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's inlined into the build and applied automatically on the first request when the database is empty and the setup wizard hasn't been completed.
 
 ## Seed File Structure
 
@@ -440,25 +440,18 @@ Set `"status": "draft"` to create unpublished content:
 }
 ```
 
-## Validation
+## Applying Seeds
 
-```bash
-npx emdash seed seed/seed.json --validate
-```
+The seed at `.emdash/seed.json`, `package.json#emdash.seed`, or `seed/seed.json` is inlined into the build and applied on the first request when the database is empty and the setup wizard hasn't been completed. Existing data is never overwritten.
 
-Catches:
+Validation runs at apply time. Common errors caught:
 
 - Image fields with raw URLs (should use `$media`)
 - Reference fields with raw IDs (should use `$ref:id`)
 - PortableText not an array or missing `_type`
 - Type mismatches (string vs number, etc.)
 
-## Applying Seeds
-
-```bash
-npx emdash seed seed/seed.json              # Apply with content
-npx emdash seed seed/seed.json --no-content  # Schema only (no sample content)
-```
+If the seed is invalid, the first request fails and the error is logged. Restart the dev server after fixing it.
 
 ## Exporting Seeds
 

--- a/.agents/skills/building-emdash-site/references/site-features.md
+++ b/.agents/skills/building-emdash-site/references/site-features.md
@@ -361,15 +361,7 @@ Bylines are automatically attached to every entry by the query layer:
 ### Standalone query functions
 
 ```typescript
-import { getEntryBylines, getByline, getBylineBySlug, getBylinesForEntries } from "emdash";
-
-// Bylines for a single entry
-const credits = await getEntryBylines("posts", post.data.id);
-
-// Batch-fetch for a list page (avoids N+1)
-const ids = entries.map((e) => e.data.id);
-const bylinesMap = await getBylinesForEntries("posts", ids);
-// bylinesMap.get(entryId) => ContentBylineCredit[]
+import { getByline, getBylineBySlug } from "emdash";
 
 // Look up a specific byline
 const byline = await getBylineBySlug("jane-doe");

--- a/.agents/skills/creating-plugins/SKILL.md
+++ b/.agents/skills/creating-plugins/SKILL.md
@@ -2,9 +2,9 @@
 description: Create EmDash CMS plugins with hooks, storage, settings, admin UI, API routes, and Portable Text block types. Use this skill when asked to build, scaffold, or implement an EmDash plugin, or when creating plugin features like custom block types, admin pages, or content hooks.
 metadata:
     github-path: skills/creating-plugins
-    github-ref: refs/tags/@emdash-cms/blocks@0.7.0
+    github-ref: refs/tags/@emdash-cms/plugin-forms@0.2.1
     github-repo: https://github.com/emdash-cms/emdash
-    github-tree-sha: 0f59766513a2e60a5f0f592819e7379b0e76a1de
+    github-tree-sha: 4a5b52aef94d28f73e041f2189979dd4d832799e
 name: creating-plugins
 ---
 # Creating EmDash Plugins
@@ -136,14 +136,14 @@ EmDash has two execution modes. Plugin code is identical in both — only the en
 
 Trusted plugins are npm packages or local files added in `astro.config.mjs`. They run in-process with your Astro site.
 
-- **Capabilities are documentation only.** Declaring `["read:content"]` documents intent but isn't enforced — the plugin has full process access.
+- **Capabilities are documentation only.** Declaring `["content:read"]` documents intent but isn't enforced — the plugin has full process access.
 - Only install from sources you trust. A malicious trusted plugin has the same access as your application code.
 
 ### Sandboxed Mode
 
 Sandboxed plugins run in isolated V8 isolates on Cloudflare Workers via [Dynamic Worker Loader](https://developers.cloudflare.com/workers/runtime-apis/bindings/worker-loader/). Each plugin gets its own isolate.
 
-- **Capabilities are enforced.** If a plugin declares `["read:content"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
+- **Capabilities are enforced.** If a plugin declares `["content:read"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
 - **Network is blocked by default.** Direct `fetch()` calls fail. Plugins must use `ctx.http.fetch()`, which validates against `allowedHosts`.
 - **Storage is scoped.** A plugin can only access its own KV and storage collections.
 - **Admin UI uses Block Kit.** Sandboxed plugins describe their UI as JSON blocks -- no plugin JavaScript runs in the browser. See [Block Kit reference](./references/block-kit.md).
@@ -165,7 +165,7 @@ export default definePlugin({
 	hooks: {
 		"content:afterSave": {
 			handler: async (event: any, ctx: PluginContext) => {
-				// Trusted: ctx.http present because descriptor declares network:fetch
+				// Trusted: ctx.http present because descriptor declares network:request
 				// Sandboxed: ctx.http present and enforced via RPC bridge
 				if (!ctx.http) return;
 				await ctx.http.fetch("https://api.analytics.example.com/track", {
@@ -184,25 +184,27 @@ Key constraint for sandbox compatibility: **no Node.js built-ins** (`fs`, `path`
 
 Capabilities control what APIs are available on `ctx`. Always declare what your plugin needs — even in trusted mode, they document intent and are required for sandboxed execution.
 
-| Capability        | Grants                                                                 | `ctx` property |
-| ----------------- | ---------------------------------------------------------------------- | -------------- |
-| `read:content`    | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
-| `write:content`   | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
-| `read:media`      | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
-| `write:media`     | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
-| `network:fetch`   | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
-| `read:users`      | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
-| `email:send`      | `ctx.email.send()` — send email through the pipeline                   | `email`        |
-| `email:provide`   | Can register `email:deliver` exclusive hook (transport provider)       | —              |
-| `email:intercept` | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| Capability                       | Grants                                                                 | `ctx` property |
+| -------------------------------- | ---------------------------------------------------------------------- | -------------- |
+| `content:read`                   | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
+| `content:write`                  | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
+| `media:read`                     | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
+| `media:write`                    | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
+| `network:request`                | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
+| `network:request:unrestricted`   | `ctx.http.fetch()` (unrestricted — for user-configured URLs)           | `http`         |
+| `users:read`                     | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
+| `email:send`                     | `ctx.email.send()` — send email through the pipeline                   | `email`        |
+| `hooks.email-transport:register` | Can register `email:deliver` exclusive hook (transport provider)       | —              |
+| `hooks.email-events:register`    | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| `hooks.page-fragments:register`  | Can register `page:fragments` hook (inject scripts/styles into pages)  | —              |
 
 Storage (`ctx.storage`) and KV (`ctx.kv`) are **always available** — no capability needed. They're automatically scoped to the plugin.
 
 **Email capabilities are distinct:**
 
 - `email:send` — for plugins that _consume_ email (call `ctx.email.send()`)
-- `email:provide` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
-- `email:intercept` — for plugins that _observe or transform_ email (middleware hooks)
+- `hooks.email-transport:register` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
+- `hooks.email-events:register` — for plugins that _observe or transform_ email (middleware hooks)
 
 ```typescript
 // In the descriptor (index.ts)
@@ -213,7 +215,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com", "*.googleapis.com"], // Wildcards supported
 	};
 }
@@ -300,7 +302,7 @@ export function submissionsPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/plugin-submissions/sandbox",
 		options: {},
-		capabilities: ["read:content"],
+		capabilities: ["content:read"],
 		storage: {
 			submissions: {
 				indexes: ["formId", "status", "createdAt"],
@@ -419,10 +421,10 @@ interface PluginContext {
 	storage: Record<string, StorageCollection>; // Declared collections
 	kv: KVAccess; // Key-value store
 	log: LogAccess; // Structured logger
-	content?: ContentAccess; // If "read:content" capability
-	media?: MediaAccess; // If "read:media" capability
-	http?: HttpAccess; // If "network:fetch" capability
-	users?: UserAccess; // If "read:users" capability
+	content?: ContentAccess; // If "content:read" capability
+	media?: MediaAccess; // If "media:read" capability
+	http?: HttpAccess; // If "network:request" capability
+	users?: UserAccess; // If "users:read" capability
 	cron?: CronAccess; // Always available — scoped to plugin
 	email?: EmailAccess; // If "email:send" capability AND a provider is configured
 }
@@ -439,7 +441,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com"],
 		storage: { events: { indexes: ["timestamp"] } },
 	};

--- a/.agents/skills/creating-plugins/references/api-routes.md
+++ b/.agents/skills/creating-plugins/references/api-routes.md
@@ -215,11 +215,11 @@ routes: {
 
 ### External API Proxy
 
-Requires `network:fetch` capability and `allowedHosts`:
+Requires `network:request` capability and `allowedHosts`:
 
 ```typescript
 definePlugin({
-	capabilities: ["network:fetch"],
+	capabilities: ["network:request"],
 	allowedHosts: ["api.weather.example.com"],
 
 	routes: {

--- a/.agents/skills/creating-plugins/references/hooks.md
+++ b/.agents/skills/creating-plugins/references/hooks.md
@@ -233,14 +233,14 @@ Email hooks require specific capabilities. Without the required capability, hook
 
 ### `email:beforeSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs before email delivery. Return modified message, or `false` to cancel delivery. Handlers are chained — each receives the output of the previous one.
 
 ```typescript
 definePlugin({
 	id: "email-footer",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:beforeSend": async (event, ctx) => {
 			return { ...event.message, text: event.message.text + "\n\n-- Sent via EmDash" };
@@ -254,14 +254,14 @@ Returns: `EmailMessage | false`
 
 ### `email:deliver`
 
-**Requires:** `email:provide` capability. **Exclusive hook** — exactly one provider is active.
+**Requires:** `hooks.email-transport:register` capability. **Exclusive hook** — exactly one provider is active.
 
 Implements email transport (e.g. Resend, SMTP, SES). Selected by the admin in Settings > Email.
 
 ```typescript
 definePlugin({
 	id: "emdash-resend",
-	capabilities: ["email:provide", "network:fetch"],
+	capabilities: ["hooks.email-transport:register", "network:request"],
 	allowedHosts: ["api.resend.com"],
 	hooks: {
 		"email:deliver": {
@@ -284,14 +284,14 @@ Returns: `void`
 
 ### `email:afterSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs after successful delivery. Fire-and-forget — errors are logged but don't propagate.
 
 ```typescript
 definePlugin({
 	id: "email-logger",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:afterSend": async (event, ctx) => {
 			ctx.log.info(`Email sent to ${event.message.to}`, { source: event.source });
@@ -418,23 +418,23 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 
 ## Quick Reference
 
-| Hook                     | Trigger              | Capability Required | Return                       |
-| ------------------------ | -------------------- | ------------------- | ---------------------------- |
-| `plugin:install`         | First install        | —                   | `void`                       |
-| `plugin:activate`        | Plugin enabled       | —                   | `void`                       |
-| `plugin:deactivate`      | Plugin disabled      | —                   | `void`                       |
-| `plugin:uninstall`       | Plugin removed       | —                   | `void`                       |
-| `content:beforeSave`     | Before save          | —                   | Modified content or `void`   |
-| `content:afterSave`      | After save           | —                   | `void`                       |
-| `content:beforeDelete`   | Before delete        | —                   | `false` to cancel            |
-| `content:afterDelete`    | After delete         | —                   | `void`                       |
-| `content:afterPublish`   | After publish        | —                   | `void`                       |
-| `content:afterUnpublish` | After unpublish      | —                   | `void`                       |
-| `media:beforeUpload`     | Before upload        | —                   | Modified file info or `void` |
-| `media:afterUpload`      | After upload         | —                   | `void`                       |
-| `email:beforeSend`       | Before email send    | `email:intercept`   | Modified message or `false`  |
-| `email:deliver`          | Email delivery       | `email:provide`     | `void` (exclusive)           |
-| `email:afterSend`        | After email send     | `email:intercept`   | `void`                       |
-| `cron`                   | Scheduled task fires | —                   | `void`                       |
-| `page:metadata`          | Page render          | —                   | Metadata contributions       |
-| `page:fragments`         | Page render          | — (trusted only)    | Fragment contributions       |
+| Hook                     | Trigger              | Capability Required              | Return                       |
+| ------------------------ | -------------------- | -------------------------------- | ---------------------------- |
+| `plugin:install`         | First install        | —                                | `void`                       |
+| `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
+| `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
+| `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | `content:write`                  | Modified content or `void`   |
+| `content:afterSave`      | After save           | `content:read`                   | `void`                       |
+| `content:beforeDelete`   | Before delete        | `content:read`                   | `false` to cancel            |
+| `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
+| `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
+| `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
+| `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
+| `media:afterUpload`      | After upload         | —                                | `void`                       |
+| `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |
+| `email:deliver`          | Email delivery       | `hooks.email-transport:register` | `void` (exclusive)           |
+| `email:afterSend`        | After email send     | `hooks.email-events:register`    | `void`                       |
+| `cron`                   | Scheduled task fires | —                                | `void`                       |
+| `page:metadata`          | Page render          | —                                | Metadata contributions       |
+| `page:fragments`         | Page render          | — (trusted only)                 | Fragment contributions       |

--- a/.agents/skills/emdash-cli/SKILL.md
+++ b/.agents/skills/emdash-cli/SKILL.md
@@ -2,9 +2,9 @@
 description: Use the EmDash CLI to manage content, schema, media, and more. Use this skill when you need to interact with a running EmDash instance from the command line — creating content, managing collections, uploading media, generating types, or scripting CMS operations.
 metadata:
     github-path: skills/emdash-cli
-    github-ref: refs/tags/@emdash-cms/blocks@0.7.0
+    github-ref: refs/tags/@emdash-cms/plugin-forms@0.2.1
     github-repo: https://github.com/emdash-cms/emdash
-    github-tree-sha: 1f975af6b5e2ae2ccb2883960aacdec89c94cc00
+    github-tree-sha: fbdedf96d07a0efe2a85101b1ff32ddbd2d0f6d1
 name: emdash-cli
 ---
 # EmDash CLI
@@ -74,22 +74,21 @@ npx emdash login --url https://example.com -H "X-API-Key: secret123"
 
 ### Database Setup
 
-```bash
-# Initialize database with migrations
-npx emdash init
+Migrations and seed application happen automatically inside the runtime — there's no separate init/seed step. Just start the dev server (or deploy) and the first request runs pending migrations and applies the bundled seed if the database is empty.
 
-# Start dev server (runs migrations, starts Astro)
+```bash
+# Start dev server (runs migrations, applies seed on empty DB, starts Astro)
 npx emdash dev
 
 # Start dev server and generate types from remote
 npx emdash dev --types
 
-# Apply a seed file
-npx emdash seed .emdash/seed.json
-
-# Export database as seed
-npx emdash export-seed > seed.json
-npx emdash export-seed --with-content > seed.json
+# Export an existing database as a seed file
+# (the runtime auto-discovers .emdash/seed.json on first boot;
+# `mkdir -p` because the directory may not exist yet)
+mkdir -p .emdash
+npx emdash export-seed > .emdash/seed.json
+npx emdash export-seed --with-content > .emdash/seed.json
 ```
 
 ### Type Generation
@@ -181,7 +180,7 @@ npx emdash schema add-field posts featured --type boolean --required
 npx emdash schema remove-field posts featured
 ```
 
-Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `image`, `reference`, `portableText`, `json`.
+Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `select`, `multiSelect`, `image`, `file`, `reference`, `portableText`, `json`, `slug`, `url`. See `FIELD_TYPE_TO_COLUMN` in `packages/core/src/schema/types.ts` for the authoritative list.
 
 ### Media
 

--- a/.agents/skills/wordpress-plugin-to-emdash/SKILL.md
+++ b/.agents/skills/wordpress-plugin-to-emdash/SKILL.md
@@ -1,0 +1,301 @@
+---
+description: Port a WordPress plugin to EmDash CMS. Use this skill when asked to migrate, convert, or port a WordPress plugin, theme functionality, or custom post type to EmDash. Provides concept mapping and implementation patterns.
+metadata:
+    github-path: skills/wordpress-plugin-to-emdash
+    github-ref: refs/tags/@emdash-cms/plugin-forms@0.2.1
+    github-repo: https://github.com/emdash-cms/emdash
+    github-tree-sha: 8b0031a4ebc0af12170fae2856d33aaf60254bf4
+name: wordpress-plugin-to-emdash
+---
+# Porting WordPress Plugins to EmDash
+
+This skill maps WordPress concepts to their EmDash equivalents for plugin porting. For general plugin authoring details (plugin structure, `definePlugin()`, hooks, storage, admin UI, etc.), use the **creating-plugins** skill.
+
+## Migration Approach
+
+1. **Understand the plugin** — What does it do, not how
+2. **Identify concepts** — Content types, admin pages, hooks, shortcodes
+3. **Map to EmDash** — Use the tables below
+4. **Implement in TypeScript** — Clean room, not line-by-line port. Use the **creating-plugins** skill for implementation details.
+5. **Test behaviour** — Same result, different implementation
+
+## Concept Mapping
+
+### Content & Data
+
+| WordPress               | EmDash                                    | Notes                                         |
+| ----------------------- | ----------------------------------------- | --------------------------------------------- |
+| `register_post_type()`  | `SchemaRegistry.createCollection()`       | Via Admin API or seed file                    |
+| `register_taxonomy()`   | `_emdash_taxonomy_defs` table             | Hierarchical or flat, attached to collections |
+| `register_meta()` / ACF | Collection fields via SchemaRegistry      | All become typed schema fields                |
+| `get_post_meta()`       | `entry.data.fieldName`                    | Direct typed access                           |
+| `get_option()`          | `getSiteSetting()` / `ctx.kv`             | Site settings or plugin-namespaced KV         |
+| `WP_Query`              | `getEmDashCollection()`                   | Runtime queries with filters                  |
+| `get_post($id)`         | `getEmDashEntry(collection, slug)`        | Returns entry or null                         |
+| `wp_insert_post()`      | `POST /_emdash/api/content/{type}`        | REST API                                      |
+| `wp_update_post()`      | `PUT /_emdash/api/content/{type}/{id}`    | REST API                                      |
+| `wp_delete_post()`      | `DELETE /_emdash/api/content/{type}/{id}` | Soft delete                                   |
+| Custom tables           | Plugin storage collections                | `ctx.storage.collectionName.put/get/query`    |
+
+### Site Configuration
+
+| WordPress                | EmDash                      | Notes                                    |
+| ------------------------ | --------------------------- | ---------------------------------------- |
+| `get_bloginfo('name')`   | `getSiteSetting('title')`   | From `options` table with `site:` prefix |
+| `get_option('blogdesc')` | `getSiteSetting('tagline')` | Site settings API                        |
+| Theme Customizer         | Site Settings admin page    | `/_emdash/admin/settings`                |
+| `site_icon`              | `getSiteSetting('favicon')` | Media reference                          |
+| `custom_logo`            | `getSiteSetting('logo')`    | Media reference                          |
+
+### Navigation Menus
+
+| WordPress              | EmDash                                  | Notes                               |
+| ---------------------- | --------------------------------------- | ----------------------------------- |
+| `register_nav_menu()`  | Create menu via admin or seed           | `_emdash_menus` table               |
+| `wp_nav_menu()`        | `getMenu(name)`                         | Returns `{ items: MenuItem[] }`     |
+| `wp_nav_menu_item`     | `_emdash_menu_items` table              | Type: custom, page, post, taxonomy  |
+| `_menu_item_object_id` | `reference_id` + `reference_collection` | Links to content entries            |
+| Menu locations         | Query by name in templates              | No locations concept — direct query |
+
+### Taxonomies
+
+| WordPress             | EmDash                                  | Notes                          |
+| --------------------- | --------------------------------------- | ------------------------------ |
+| `register_taxonomy()` | `_emdash_taxonomy_defs` table           | Define via admin, seed, or API |
+| `get_terms()`         | `getTaxonomyTerms(name)`                | Returns tree for hierarchical  |
+| `get_the_terms()`     | `getEntryTerms(collection, id, name)`   | Terms for specific entry       |
+| `wp_set_post_terms()` | `TaxonomyRepository.setTermsForEntry()` | Replace terms for entry        |
+| Hierarchical taxonomy | `hierarchical: true` in definition      | Categories-style               |
+| Flat taxonomy         | `hierarchical: false`                   | Tags-style                     |
+
+### Widgets & Sidebars
+
+| WordPress            | EmDash                                 | Notes                           |
+| -------------------- | -------------------------------------- | ------------------------------- |
+| `register_sidebar()` | `_emdash_widget_areas` table           | Create via admin or seed        |
+| `dynamic_sidebar()`  | `getWidgetArea(name)`                  | Returns `{ widgets: Widget[] }` |
+| `WP_Widget` class    | Widget types: content, menu, component | Simplified — 3 types only       |
+| Text widget          | `type: 'content'` + Portable Text      | Rich text widget                |
+| Nav Menu widget      | `type: 'menu'` + `menuName`            | References a menu               |
+| Custom widgets       | `type: 'component'` + `componentId`    | Plugin-registered components    |
+
+### Admin UI
+
+| WordPress                | EmDash                            | Notes                                    |
+| ------------------------ | --------------------------------- | ---------------------------------------- |
+| `add_menu_page()`        | `admin.pages` in `definePlugin()` | Plugin config                            |
+| `add_submenu_page()`     | Nested admin pages                | Parent determines hierarchy              |
+| `add_settings_section()` | `admin.settingsSchema`            | Auto-generated settings page             |
+| `add_meta_box()`         | Field groups in collection schema | UI config in schema                      |
+| `wp_enqueue_script()`    | ESM imports in admin components   | React (trusted) or Block Kit (sandboxed) |
+| Admin notices            | Toast notifications               | Via admin UI framework                   |
+
+### Hooks
+
+| WordPress                          | EmDash                                  | Notes                                                 |
+| ---------------------------------- | --------------------------------------- | ----------------------------------------------------- |
+| `add_action('init')`               | `plugin:install` hook                   | Runs once on first install                            |
+| `add_action('save_post')`          | `content:afterSave` hook                | Filter by `event.collection`                          |
+| `add_action('before_delete_post')` | `content:beforeDelete` hook             | Return false to prevent                               |
+| `add_action('wp_head')`            | `page:metadata` / `page:fragments` hook | Metadata is sandbox-safe; scripts need trusted plugin |
+| `add_action('rest_api_init')`      | `definePlugin({ routes })`              | Trusted only                                          |
+| `add_filter('the_content')`        | Portable Text components                | Custom block renderers                                |
+| `add_filter('the_title')`          | Template logic                          | Handle in Astro component                             |
+
+### Frontend Output
+
+| WordPress               | EmDash                       | Notes                                                |
+| ----------------------- | ---------------------------- | ---------------------------------------------------- |
+| `add_shortcode()`       | Portable Text custom block   | Content → block. Template → component. Trusted only. |
+| `register_block_type()` | PT block + `componentsEntry` | Block data → Astro component props. Trusted only.    |
+| Template tags           | Astro expressions            | `get_the_title()` → `{post.data.title}`              |
+| Widgets                 | Widget area + components     | Query with `getWidgetArea()`                         |
+
+### Plugin Storage
+
+| WordPress                | EmDash                   | Notes                              |
+| ------------------------ | ------------------------ | ---------------------------------- |
+| `get_option('plugin_*')` | `ctx.kv.get(key)`        | Namespaced to plugin automatically |
+| `update_option()`        | `ctx.kv.set(key, value)` | Scoped KV storage                  |
+| `delete_option()`        | `ctx.kv.delete(key)`     | Delete single key                  |
+| Custom tables            | `ctx.storage.collection` | Document collections with indexes  |
+| Transients               | Plugin KV                | No TTL yet                         |
+
+## Porting-Specific Patterns
+
+These patterns cover WordPress-specific concepts that don't have a direct 1:1 mapping. For general plugin patterns (defining hooks, storage, routes, admin UI), see the **creating-plugins** skill.
+
+### Shortcodes → Portable Text Blocks
+
+WordPress shortcodes (`[youtube id="xxx"]`) become Portable Text custom block types. The block data replaces shortcode attributes, and an Astro component replaces the shortcode render function. This is a trusted-only feature.
+
+```typescript
+// WordPress
+add_shortcode('youtube', function($atts) {
+    return '<iframe src="https://youtube.com/embed/' . $atts['id'] . '"></iframe>';
+});
+
+// EmDash — block type declaration in definePlugin()
+admin: {
+	portableTextBlocks: [{
+		type: "youtube",
+		label: "YouTube Video",
+		icon: "video",
+		fields: [
+			{ type: "text_input", action_id: "id", label: "YouTube URL" },
+			{ type: "text_input", action_id: "title", label: "Title" },
+		],
+	}],
+}
+
+// EmDash — Astro component for rendering
+// src/astro/YouTube.astro
+const { id, title } = Astro.props.node;
+const videoId = id?.match(/(?:v=|youtu\.be\/)([^&]+)/)?.[1] ?? id;
+// <iframe src={`https://youtube-nocookie.com/embed/${videoId}`} ... />
+```
+
+### Options API → Plugin KV
+
+WordPress's `get_option`/`update_option` maps to the plugin KV store. The key difference: WordPress options are global, EmDash KV is automatically scoped to the plugin.
+
+```typescript
+// WordPress
+$count = get_option("myplugin_post_count", 0);
+update_option("myplugin_post_count", $count + 1);
+delete_option("myplugin_temp_data");
+
+// EmDash — no prefix needed, automatically scoped
+const count = (await ctx.kv.get<number>("post-count")) ?? 0;
+await ctx.kv.set("post-count", count + 1);
+await ctx.kv.delete("temp-data");
+```
+
+### Custom Database Tables → Storage Collections
+
+WordPress plugins that create custom tables with `$wpdb->query("CREATE TABLE ...")` should use EmDash's storage collections instead. No migrations needed — declare the schema in `definePlugin()` and it's automatically provisioned.
+
+```typescript
+// WordPress
+$wpdb->insert($table, ['form_id' => $id, 'data' => json_encode($data), 'created_at' => current_time('mysql')]);
+$results = $wpdb->get_results("SELECT * FROM $table WHERE form_id = '$id' ORDER BY created_at DESC LIMIT 50");
+
+// EmDash — declared in definePlugin()
+storage: {
+	submissions: {
+		indexes: ["formId", "createdAt", ["formId", "createdAt"]],
+	},
+},
+
+// In a hook or route handler
+await ctx.storage.submissions!.put(entryId, { formId, data, createdAt: new Date().toISOString() });
+const result = await ctx.storage.submissions!.query({
+	where: { formId },
+	orderBy: { createdAt: "desc" },
+	limit: 50,
+});
+```
+
+### Seeding Data (replaces starter content, theme setup)
+
+WordPress plugins that call `wp_insert_term()`, `register_nav_menu()`, or insert default content on activation should use a seed file:
+
+```json
+{
+	"version": "1",
+	"settings": { "title": "My Site", "tagline": "Welcome" },
+	"taxonomies": [
+		{
+			"name": "category",
+			"label": "Categories",
+			"hierarchical": true,
+			"collections": ["posts"],
+			"terms": [
+				{ "slug": "news", "label": "News" },
+				{ "slug": "tutorials", "label": "Tutorials" }
+			]
+		}
+	],
+	"menus": [
+		{
+			"name": "primary",
+			"label": "Primary Navigation",
+			"items": [
+				{ "type": "custom", "label": "Home", "url": "/" },
+				{ "type": "page", "ref": "about", "collection": "pages" }
+			]
+		}
+	],
+	"redirects": [
+		{ "source": "/?p=123", "destination": "/about" },
+		{ "source": "/old-contact", "destination": "/contact", "type": 301 }
+	]
+}
+```
+
+Save to `.emdash/seed.json` (or wire up via `package.json#emdash.seed`); the runtime applies it on the next first-boot when the database is empty.
+
+Use `redirects` for legacy WordPress URLs that still receive traffic after migration.
+
+### Querying Content (replaces WP_Query)
+
+```typescript
+// WordPress
+$query = new WP_Query(['post_type' => 'post', 'category_name' => 'tech', 'posts_per_page' => 10]);
+
+// EmDash — in Astro component frontmatter
+import { getEmDashCollection, getEntryTerms } from "emdash";
+const { entries } = await getEmDashCollection("posts", {
+	where: { category: "technology" },
+	limit: 10,
+});
+```
+
+### Menus (replaces wp_nav_menu)
+
+```typescript
+// WordPress
+wp_nav_menu(['theme_location' => 'primary']);
+
+// EmDash — in Astro component
+import { getMenu } from "emdash";
+const nav = await getMenu("primary");
+// nav.items[].label, nav.items[].url, nav.items[].children
+```
+
+### Widget Areas (replaces dynamic_sidebar)
+
+```typescript
+// WordPress
+dynamic_sidebar("sidebar-1");
+
+// EmDash — in Astro component
+import { getWidgetArea } from "emdash";
+const sidebar = await getWidgetArea("sidebar");
+// sidebar.widgets[].type: "content" | "menu" | "component"
+```
+
+## Red Flags (Need Human Decision)
+
+Flag these for review — they may need architectural decisions:
+
+1. **Deep WP integration** — Hooks into WP core features not in EmDash
+2. **Theme dependencies** — Assumes specific theme structure
+3. **Multisite features** — Not supported
+4. **Complex WP_Query** — Meta queries may need custom implementation
+5. **Direct SQL** — Schema differs, use Kysely or plugin storage
+6. **Session/transient abuse** — Needs proper caching layer
+7. **User capability checks** — Review role mapping (future)
+8. **ob_start() buffering** — PHP pattern, rethink for streaming
+9. **Cron jobs** — `wp_schedule_event()` has no direct equivalent; needs platform cron
+
+## Output Format
+
+When porting a plugin, provide:
+
+1. **Analysis** — What the WP plugin does (concepts, not code)
+2. **Concept mapping** — Which WP concepts map to which EmDash features
+3. **Plugin code** — `src/descriptor.ts` and `src/index.ts` (use **creating-plugins** skill for structure)
+4. **Seed data** — If plugin needs default taxonomies/menus/widgets
+5. **Astro components** — For frontend output
+6. **Flags** — Anything needing human decision

--- a/.claude/skills/building-emdash-site/SKILL.md
+++ b/.claude/skills/building-emdash-site/SKILL.md
@@ -2,9 +2,9 @@
 description: Build and customize EmDash CMS sites on Astro. Use when creating pages, defining collections, writing seed files, querying content, rendering Portable Text, setting up menus/taxonomies/widgets, configuring deployment, or any task involving an EmDash-powered Astro site. Assumes basic Astro knowledge but provides all EmDash-specific patterns.
 metadata:
     github-path: skills/building-emdash-site
-    github-ref: refs/tags/@emdash-cms/blocks@0.7.0
+    github-ref: refs/tags/@emdash-cms/plugin-forms@0.2.1
     github-repo: https://github.com/emdash-cms/emdash
-    github-tree-sha: ffdc2a30429240e99f442bc4ae066515c229fae4
+    github-tree-sha: 3750da8003604a48db0db020cf1a3640ee8ac7de
 name: building-emdash-site
 ---
 # Building an EmDash Site
@@ -63,11 +63,7 @@ Read **[references/site-features.md](references/site-features.md)** for site set
 
 ### 5. Create the seed file
 
-Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content. Validate with:
-
-```bash
-npx emdash seed seed/seed.json --validate
-```
+Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content.
 
 ### 6. Run and verify
 
@@ -104,7 +100,7 @@ import {
 } from "emdash";
 
 // Bylines (standalone queries -- usually not needed since entries have bylines attached)
-import { getEntryBylines, getBylinesForEntries, getByline, getBylineBySlug } from "emdash";
+import { getByline, getBylineBySlug } from "emdash";
 
 // UI components
 import {

--- a/.claude/skills/building-emdash-site/references/configuration.md
+++ b/.claude/skills/building-emdash-site/references/configuration.md
@@ -97,7 +97,6 @@ Requires a `wrangler.jsonc` with D1 and R2 bindings:
 		{
 			"binding": "DB",
 			"database_name": "my-site",
-			"database_id": "", // from `wrangler d1 create my-site`
 		},
 	],
 	"r2_buckets": [

--- a/.claude/skills/building-emdash-site/references/schema-and-seed.md
+++ b/.claude/skills/building-emdash-site/references/schema-and-seed.md
@@ -1,6 +1,6 @@
 # Schema and Seed Files
 
-The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's applied on first run or via `npx emdash seed seed/seed.json`.
+The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's inlined into the build and applied automatically on the first request when the database is empty and the setup wizard hasn't been completed.
 
 ## Seed File Structure
 
@@ -440,25 +440,18 @@ Set `"status": "draft"` to create unpublished content:
 }
 ```
 
-## Validation
+## Applying Seeds
 
-```bash
-npx emdash seed seed/seed.json --validate
-```
+The seed at `.emdash/seed.json`, `package.json#emdash.seed`, or `seed/seed.json` is inlined into the build and applied on the first request when the database is empty and the setup wizard hasn't been completed. Existing data is never overwritten.
 
-Catches:
+Validation runs at apply time. Common errors caught:
 
 - Image fields with raw URLs (should use `$media`)
 - Reference fields with raw IDs (should use `$ref:id`)
 - PortableText not an array or missing `_type`
 - Type mismatches (string vs number, etc.)
 
-## Applying Seeds
-
-```bash
-npx emdash seed seed/seed.json              # Apply with content
-npx emdash seed seed/seed.json --no-content  # Schema only (no sample content)
-```
+If the seed is invalid, the first request fails and the error is logged. Restart the dev server after fixing it.
 
 ## Exporting Seeds
 

--- a/.claude/skills/building-emdash-site/references/site-features.md
+++ b/.claude/skills/building-emdash-site/references/site-features.md
@@ -361,15 +361,7 @@ Bylines are automatically attached to every entry by the query layer:
 ### Standalone query functions
 
 ```typescript
-import { getEntryBylines, getByline, getBylineBySlug, getBylinesForEntries } from "emdash";
-
-// Bylines for a single entry
-const credits = await getEntryBylines("posts", post.data.id);
-
-// Batch-fetch for a list page (avoids N+1)
-const ids = entries.map((e) => e.data.id);
-const bylinesMap = await getBylinesForEntries("posts", ids);
-// bylinesMap.get(entryId) => ContentBylineCredit[]
+import { getByline, getBylineBySlug } from "emdash";
 
 // Look up a specific byline
 const byline = await getBylineBySlug("jane-doe");

--- a/.claude/skills/creating-plugins/SKILL.md
+++ b/.claude/skills/creating-plugins/SKILL.md
@@ -2,9 +2,9 @@
 description: Create EmDash CMS plugins with hooks, storage, settings, admin UI, API routes, and Portable Text block types. Use this skill when asked to build, scaffold, or implement an EmDash plugin, or when creating plugin features like custom block types, admin pages, or content hooks.
 metadata:
     github-path: skills/creating-plugins
-    github-ref: refs/tags/@emdash-cms/blocks@0.7.0
+    github-ref: refs/tags/@emdash-cms/plugin-forms@0.2.1
     github-repo: https://github.com/emdash-cms/emdash
-    github-tree-sha: 0f59766513a2e60a5f0f592819e7379b0e76a1de
+    github-tree-sha: 4a5b52aef94d28f73e041f2189979dd4d832799e
 name: creating-plugins
 ---
 # Creating EmDash Plugins
@@ -136,14 +136,14 @@ EmDash has two execution modes. Plugin code is identical in both — only the en
 
 Trusted plugins are npm packages or local files added in `astro.config.mjs`. They run in-process with your Astro site.
 
-- **Capabilities are documentation only.** Declaring `["read:content"]` documents intent but isn't enforced — the plugin has full process access.
+- **Capabilities are documentation only.** Declaring `["content:read"]` documents intent but isn't enforced — the plugin has full process access.
 - Only install from sources you trust. A malicious trusted plugin has the same access as your application code.
 
 ### Sandboxed Mode
 
 Sandboxed plugins run in isolated V8 isolates on Cloudflare Workers via [Dynamic Worker Loader](https://developers.cloudflare.com/workers/runtime-apis/bindings/worker-loader/). Each plugin gets its own isolate.
 
-- **Capabilities are enforced.** If a plugin declares `["read:content"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
+- **Capabilities are enforced.** If a plugin declares `["content:read"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
 - **Network is blocked by default.** Direct `fetch()` calls fail. Plugins must use `ctx.http.fetch()`, which validates against `allowedHosts`.
 - **Storage is scoped.** A plugin can only access its own KV and storage collections.
 - **Admin UI uses Block Kit.** Sandboxed plugins describe their UI as JSON blocks -- no plugin JavaScript runs in the browser. See [Block Kit reference](./references/block-kit.md).
@@ -165,7 +165,7 @@ export default definePlugin({
 	hooks: {
 		"content:afterSave": {
 			handler: async (event: any, ctx: PluginContext) => {
-				// Trusted: ctx.http present because descriptor declares network:fetch
+				// Trusted: ctx.http present because descriptor declares network:request
 				// Sandboxed: ctx.http present and enforced via RPC bridge
 				if (!ctx.http) return;
 				await ctx.http.fetch("https://api.analytics.example.com/track", {
@@ -184,25 +184,27 @@ Key constraint for sandbox compatibility: **no Node.js built-ins** (`fs`, `path`
 
 Capabilities control what APIs are available on `ctx`. Always declare what your plugin needs — even in trusted mode, they document intent and are required for sandboxed execution.
 
-| Capability        | Grants                                                                 | `ctx` property |
-| ----------------- | ---------------------------------------------------------------------- | -------------- |
-| `read:content`    | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
-| `write:content`   | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
-| `read:media`      | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
-| `write:media`     | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
-| `network:fetch`   | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
-| `read:users`      | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
-| `email:send`      | `ctx.email.send()` — send email through the pipeline                   | `email`        |
-| `email:provide`   | Can register `email:deliver` exclusive hook (transport provider)       | —              |
-| `email:intercept` | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| Capability                       | Grants                                                                 | `ctx` property |
+| -------------------------------- | ---------------------------------------------------------------------- | -------------- |
+| `content:read`                   | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
+| `content:write`                  | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
+| `media:read`                     | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
+| `media:write`                    | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
+| `network:request`                | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
+| `network:request:unrestricted`   | `ctx.http.fetch()` (unrestricted — for user-configured URLs)           | `http`         |
+| `users:read`                     | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
+| `email:send`                     | `ctx.email.send()` — send email through the pipeline                   | `email`        |
+| `hooks.email-transport:register` | Can register `email:deliver` exclusive hook (transport provider)       | —              |
+| `hooks.email-events:register`    | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| `hooks.page-fragments:register`  | Can register `page:fragments` hook (inject scripts/styles into pages)  | —              |
 
 Storage (`ctx.storage`) and KV (`ctx.kv`) are **always available** — no capability needed. They're automatically scoped to the plugin.
 
 **Email capabilities are distinct:**
 
 - `email:send` — for plugins that _consume_ email (call `ctx.email.send()`)
-- `email:provide` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
-- `email:intercept` — for plugins that _observe or transform_ email (middleware hooks)
+- `hooks.email-transport:register` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
+- `hooks.email-events:register` — for plugins that _observe or transform_ email (middleware hooks)
 
 ```typescript
 // In the descriptor (index.ts)
@@ -213,7 +215,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com", "*.googleapis.com"], // Wildcards supported
 	};
 }
@@ -300,7 +302,7 @@ export function submissionsPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/plugin-submissions/sandbox",
 		options: {},
-		capabilities: ["read:content"],
+		capabilities: ["content:read"],
 		storage: {
 			submissions: {
 				indexes: ["formId", "status", "createdAt"],
@@ -419,10 +421,10 @@ interface PluginContext {
 	storage: Record<string, StorageCollection>; // Declared collections
 	kv: KVAccess; // Key-value store
 	log: LogAccess; // Structured logger
-	content?: ContentAccess; // If "read:content" capability
-	media?: MediaAccess; // If "read:media" capability
-	http?: HttpAccess; // If "network:fetch" capability
-	users?: UserAccess; // If "read:users" capability
+	content?: ContentAccess; // If "content:read" capability
+	media?: MediaAccess; // If "media:read" capability
+	http?: HttpAccess; // If "network:request" capability
+	users?: UserAccess; // If "users:read" capability
 	cron?: CronAccess; // Always available — scoped to plugin
 	email?: EmailAccess; // If "email:send" capability AND a provider is configured
 }
@@ -439,7 +441,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com"],
 		storage: { events: { indexes: ["timestamp"] } },
 	};

--- a/.claude/skills/creating-plugins/references/api-routes.md
+++ b/.claude/skills/creating-plugins/references/api-routes.md
@@ -215,11 +215,11 @@ routes: {
 
 ### External API Proxy
 
-Requires `network:fetch` capability and `allowedHosts`:
+Requires `network:request` capability and `allowedHosts`:
 
 ```typescript
 definePlugin({
-	capabilities: ["network:fetch"],
+	capabilities: ["network:request"],
 	allowedHosts: ["api.weather.example.com"],
 
 	routes: {

--- a/.claude/skills/creating-plugins/references/hooks.md
+++ b/.claude/skills/creating-plugins/references/hooks.md
@@ -233,14 +233,14 @@ Email hooks require specific capabilities. Without the required capability, hook
 
 ### `email:beforeSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs before email delivery. Return modified message, or `false` to cancel delivery. Handlers are chained — each receives the output of the previous one.
 
 ```typescript
 definePlugin({
 	id: "email-footer",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:beforeSend": async (event, ctx) => {
 			return { ...event.message, text: event.message.text + "\n\n-- Sent via EmDash" };
@@ -254,14 +254,14 @@ Returns: `EmailMessage | false`
 
 ### `email:deliver`
 
-**Requires:** `email:provide` capability. **Exclusive hook** — exactly one provider is active.
+**Requires:** `hooks.email-transport:register` capability. **Exclusive hook** — exactly one provider is active.
 
 Implements email transport (e.g. Resend, SMTP, SES). Selected by the admin in Settings > Email.
 
 ```typescript
 definePlugin({
 	id: "emdash-resend",
-	capabilities: ["email:provide", "network:fetch"],
+	capabilities: ["hooks.email-transport:register", "network:request"],
 	allowedHosts: ["api.resend.com"],
 	hooks: {
 		"email:deliver": {
@@ -284,14 +284,14 @@ Returns: `void`
 
 ### `email:afterSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs after successful delivery. Fire-and-forget — errors are logged but don't propagate.
 
 ```typescript
 definePlugin({
 	id: "email-logger",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:afterSend": async (event, ctx) => {
 			ctx.log.info(`Email sent to ${event.message.to}`, { source: event.source });
@@ -418,23 +418,23 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 
 ## Quick Reference
 
-| Hook                     | Trigger              | Capability Required | Return                       |
-| ------------------------ | -------------------- | ------------------- | ---------------------------- |
-| `plugin:install`         | First install        | —                   | `void`                       |
-| `plugin:activate`        | Plugin enabled       | —                   | `void`                       |
-| `plugin:deactivate`      | Plugin disabled      | —                   | `void`                       |
-| `plugin:uninstall`       | Plugin removed       | —                   | `void`                       |
-| `content:beforeSave`     | Before save          | —                   | Modified content or `void`   |
-| `content:afterSave`      | After save           | —                   | `void`                       |
-| `content:beforeDelete`   | Before delete        | —                   | `false` to cancel            |
-| `content:afterDelete`    | After delete         | —                   | `void`                       |
-| `content:afterPublish`   | After publish        | —                   | `void`                       |
-| `content:afterUnpublish` | After unpublish      | —                   | `void`                       |
-| `media:beforeUpload`     | Before upload        | —                   | Modified file info or `void` |
-| `media:afterUpload`      | After upload         | —                   | `void`                       |
-| `email:beforeSend`       | Before email send    | `email:intercept`   | Modified message or `false`  |
-| `email:deliver`          | Email delivery       | `email:provide`     | `void` (exclusive)           |
-| `email:afterSend`        | After email send     | `email:intercept`   | `void`                       |
-| `cron`                   | Scheduled task fires | —                   | `void`                       |
-| `page:metadata`          | Page render          | —                   | Metadata contributions       |
-| `page:fragments`         | Page render          | — (trusted only)    | Fragment contributions       |
+| Hook                     | Trigger              | Capability Required              | Return                       |
+| ------------------------ | -------------------- | -------------------------------- | ---------------------------- |
+| `plugin:install`         | First install        | —                                | `void`                       |
+| `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
+| `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
+| `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | `content:write`                  | Modified content or `void`   |
+| `content:afterSave`      | After save           | `content:read`                   | `void`                       |
+| `content:beforeDelete`   | Before delete        | `content:read`                   | `false` to cancel            |
+| `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
+| `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
+| `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
+| `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
+| `media:afterUpload`      | After upload         | —                                | `void`                       |
+| `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |
+| `email:deliver`          | Email delivery       | `hooks.email-transport:register` | `void` (exclusive)           |
+| `email:afterSend`        | After email send     | `hooks.email-events:register`    | `void`                       |
+| `cron`                   | Scheduled task fires | —                                | `void`                       |
+| `page:metadata`          | Page render          | —                                | Metadata contributions       |
+| `page:fragments`         | Page render          | — (trusted only)                 | Fragment contributions       |

--- a/.claude/skills/emdash-cli/SKILL.md
+++ b/.claude/skills/emdash-cli/SKILL.md
@@ -2,9 +2,9 @@
 description: Use the EmDash CLI to manage content, schema, media, and more. Use this skill when you need to interact with a running EmDash instance from the command line — creating content, managing collections, uploading media, generating types, or scripting CMS operations.
 metadata:
     github-path: skills/emdash-cli
-    github-ref: refs/tags/@emdash-cms/blocks@0.7.0
+    github-ref: refs/tags/@emdash-cms/plugin-forms@0.2.1
     github-repo: https://github.com/emdash-cms/emdash
-    github-tree-sha: 1f975af6b5e2ae2ccb2883960aacdec89c94cc00
+    github-tree-sha: fbdedf96d07a0efe2a85101b1ff32ddbd2d0f6d1
 name: emdash-cli
 ---
 # EmDash CLI
@@ -74,22 +74,21 @@ npx emdash login --url https://example.com -H "X-API-Key: secret123"
 
 ### Database Setup
 
-```bash
-# Initialize database with migrations
-npx emdash init
+Migrations and seed application happen automatically inside the runtime — there's no separate init/seed step. Just start the dev server (or deploy) and the first request runs pending migrations and applies the bundled seed if the database is empty.
 
-# Start dev server (runs migrations, starts Astro)
+```bash
+# Start dev server (runs migrations, applies seed on empty DB, starts Astro)
 npx emdash dev
 
 # Start dev server and generate types from remote
 npx emdash dev --types
 
-# Apply a seed file
-npx emdash seed .emdash/seed.json
-
-# Export database as seed
-npx emdash export-seed > seed.json
-npx emdash export-seed --with-content > seed.json
+# Export an existing database as a seed file
+# (the runtime auto-discovers .emdash/seed.json on first boot;
+# `mkdir -p` because the directory may not exist yet)
+mkdir -p .emdash
+npx emdash export-seed > .emdash/seed.json
+npx emdash export-seed --with-content > .emdash/seed.json
 ```
 
 ### Type Generation
@@ -181,7 +180,7 @@ npx emdash schema add-field posts featured --type boolean --required
 npx emdash schema remove-field posts featured
 ```
 
-Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `image`, `reference`, `portableText`, `json`.
+Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `select`, `multiSelect`, `image`, `file`, `reference`, `portableText`, `json`, `slug`, `url`. See `FIELD_TYPE_TO_COLUMN` in `packages/core/src/schema/types.ts` for the authoritative list.
 
 ### Media
 

--- a/.claude/skills/wordpress-plugin-to-emdash/SKILL.md
+++ b/.claude/skills/wordpress-plugin-to-emdash/SKILL.md
@@ -1,0 +1,301 @@
+---
+description: Port a WordPress plugin to EmDash CMS. Use this skill when asked to migrate, convert, or port a WordPress plugin, theme functionality, or custom post type to EmDash. Provides concept mapping and implementation patterns.
+metadata:
+    github-path: skills/wordpress-plugin-to-emdash
+    github-ref: refs/tags/@emdash-cms/plugin-forms@0.2.1
+    github-repo: https://github.com/emdash-cms/emdash
+    github-tree-sha: 8b0031a4ebc0af12170fae2856d33aaf60254bf4
+name: wordpress-plugin-to-emdash
+---
+# Porting WordPress Plugins to EmDash
+
+This skill maps WordPress concepts to their EmDash equivalents for plugin porting. For general plugin authoring details (plugin structure, `definePlugin()`, hooks, storage, admin UI, etc.), use the **creating-plugins** skill.
+
+## Migration Approach
+
+1. **Understand the plugin** — What does it do, not how
+2. **Identify concepts** — Content types, admin pages, hooks, shortcodes
+3. **Map to EmDash** — Use the tables below
+4. **Implement in TypeScript** — Clean room, not line-by-line port. Use the **creating-plugins** skill for implementation details.
+5. **Test behaviour** — Same result, different implementation
+
+## Concept Mapping
+
+### Content & Data
+
+| WordPress               | EmDash                                    | Notes                                         |
+| ----------------------- | ----------------------------------------- | --------------------------------------------- |
+| `register_post_type()`  | `SchemaRegistry.createCollection()`       | Via Admin API or seed file                    |
+| `register_taxonomy()`   | `_emdash_taxonomy_defs` table             | Hierarchical or flat, attached to collections |
+| `register_meta()` / ACF | Collection fields via SchemaRegistry      | All become typed schema fields                |
+| `get_post_meta()`       | `entry.data.fieldName`                    | Direct typed access                           |
+| `get_option()`          | `getSiteSetting()` / `ctx.kv`             | Site settings or plugin-namespaced KV         |
+| `WP_Query`              | `getEmDashCollection()`                   | Runtime queries with filters                  |
+| `get_post($id)`         | `getEmDashEntry(collection, slug)`        | Returns entry or null                         |
+| `wp_insert_post()`      | `POST /_emdash/api/content/{type}`        | REST API                                      |
+| `wp_update_post()`      | `PUT /_emdash/api/content/{type}/{id}`    | REST API                                      |
+| `wp_delete_post()`      | `DELETE /_emdash/api/content/{type}/{id}` | Soft delete                                   |
+| Custom tables           | Plugin storage collections                | `ctx.storage.collectionName.put/get/query`    |
+
+### Site Configuration
+
+| WordPress                | EmDash                      | Notes                                    |
+| ------------------------ | --------------------------- | ---------------------------------------- |
+| `get_bloginfo('name')`   | `getSiteSetting('title')`   | From `options` table with `site:` prefix |
+| `get_option('blogdesc')` | `getSiteSetting('tagline')` | Site settings API                        |
+| Theme Customizer         | Site Settings admin page    | `/_emdash/admin/settings`                |
+| `site_icon`              | `getSiteSetting('favicon')` | Media reference                          |
+| `custom_logo`            | `getSiteSetting('logo')`    | Media reference                          |
+
+### Navigation Menus
+
+| WordPress              | EmDash                                  | Notes                               |
+| ---------------------- | --------------------------------------- | ----------------------------------- |
+| `register_nav_menu()`  | Create menu via admin or seed           | `_emdash_menus` table               |
+| `wp_nav_menu()`        | `getMenu(name)`                         | Returns `{ items: MenuItem[] }`     |
+| `wp_nav_menu_item`     | `_emdash_menu_items` table              | Type: custom, page, post, taxonomy  |
+| `_menu_item_object_id` | `reference_id` + `reference_collection` | Links to content entries            |
+| Menu locations         | Query by name in templates              | No locations concept — direct query |
+
+### Taxonomies
+
+| WordPress             | EmDash                                  | Notes                          |
+| --------------------- | --------------------------------------- | ------------------------------ |
+| `register_taxonomy()` | `_emdash_taxonomy_defs` table           | Define via admin, seed, or API |
+| `get_terms()`         | `getTaxonomyTerms(name)`                | Returns tree for hierarchical  |
+| `get_the_terms()`     | `getEntryTerms(collection, id, name)`   | Terms for specific entry       |
+| `wp_set_post_terms()` | `TaxonomyRepository.setTermsForEntry()` | Replace terms for entry        |
+| Hierarchical taxonomy | `hierarchical: true` in definition      | Categories-style               |
+| Flat taxonomy         | `hierarchical: false`                   | Tags-style                     |
+
+### Widgets & Sidebars
+
+| WordPress            | EmDash                                 | Notes                           |
+| -------------------- | -------------------------------------- | ------------------------------- |
+| `register_sidebar()` | `_emdash_widget_areas` table           | Create via admin or seed        |
+| `dynamic_sidebar()`  | `getWidgetArea(name)`                  | Returns `{ widgets: Widget[] }` |
+| `WP_Widget` class    | Widget types: content, menu, component | Simplified — 3 types only       |
+| Text widget          | `type: 'content'` + Portable Text      | Rich text widget                |
+| Nav Menu widget      | `type: 'menu'` + `menuName`            | References a menu               |
+| Custom widgets       | `type: 'component'` + `componentId`    | Plugin-registered components    |
+
+### Admin UI
+
+| WordPress                | EmDash                            | Notes                                    |
+| ------------------------ | --------------------------------- | ---------------------------------------- |
+| `add_menu_page()`        | `admin.pages` in `definePlugin()` | Plugin config                            |
+| `add_submenu_page()`     | Nested admin pages                | Parent determines hierarchy              |
+| `add_settings_section()` | `admin.settingsSchema`            | Auto-generated settings page             |
+| `add_meta_box()`         | Field groups in collection schema | UI config in schema                      |
+| `wp_enqueue_script()`    | ESM imports in admin components   | React (trusted) or Block Kit (sandboxed) |
+| Admin notices            | Toast notifications               | Via admin UI framework                   |
+
+### Hooks
+
+| WordPress                          | EmDash                                  | Notes                                                 |
+| ---------------------------------- | --------------------------------------- | ----------------------------------------------------- |
+| `add_action('init')`               | `plugin:install` hook                   | Runs once on first install                            |
+| `add_action('save_post')`          | `content:afterSave` hook                | Filter by `event.collection`                          |
+| `add_action('before_delete_post')` | `content:beforeDelete` hook             | Return false to prevent                               |
+| `add_action('wp_head')`            | `page:metadata` / `page:fragments` hook | Metadata is sandbox-safe; scripts need trusted plugin |
+| `add_action('rest_api_init')`      | `definePlugin({ routes })`              | Trusted only                                          |
+| `add_filter('the_content')`        | Portable Text components                | Custom block renderers                                |
+| `add_filter('the_title')`          | Template logic                          | Handle in Astro component                             |
+
+### Frontend Output
+
+| WordPress               | EmDash                       | Notes                                                |
+| ----------------------- | ---------------------------- | ---------------------------------------------------- |
+| `add_shortcode()`       | Portable Text custom block   | Content → block. Template → component. Trusted only. |
+| `register_block_type()` | PT block + `componentsEntry` | Block data → Astro component props. Trusted only.    |
+| Template tags           | Astro expressions            | `get_the_title()` → `{post.data.title}`              |
+| Widgets                 | Widget area + components     | Query with `getWidgetArea()`                         |
+
+### Plugin Storage
+
+| WordPress                | EmDash                   | Notes                              |
+| ------------------------ | ------------------------ | ---------------------------------- |
+| `get_option('plugin_*')` | `ctx.kv.get(key)`        | Namespaced to plugin automatically |
+| `update_option()`        | `ctx.kv.set(key, value)` | Scoped KV storage                  |
+| `delete_option()`        | `ctx.kv.delete(key)`     | Delete single key                  |
+| Custom tables            | `ctx.storage.collection` | Document collections with indexes  |
+| Transients               | Plugin KV                | No TTL yet                         |
+
+## Porting-Specific Patterns
+
+These patterns cover WordPress-specific concepts that don't have a direct 1:1 mapping. For general plugin patterns (defining hooks, storage, routes, admin UI), see the **creating-plugins** skill.
+
+### Shortcodes → Portable Text Blocks
+
+WordPress shortcodes (`[youtube id="xxx"]`) become Portable Text custom block types. The block data replaces shortcode attributes, and an Astro component replaces the shortcode render function. This is a trusted-only feature.
+
+```typescript
+// WordPress
+add_shortcode('youtube', function($atts) {
+    return '<iframe src="https://youtube.com/embed/' . $atts['id'] . '"></iframe>';
+});
+
+// EmDash — block type declaration in definePlugin()
+admin: {
+	portableTextBlocks: [{
+		type: "youtube",
+		label: "YouTube Video",
+		icon: "video",
+		fields: [
+			{ type: "text_input", action_id: "id", label: "YouTube URL" },
+			{ type: "text_input", action_id: "title", label: "Title" },
+		],
+	}],
+}
+
+// EmDash — Astro component for rendering
+// src/astro/YouTube.astro
+const { id, title } = Astro.props.node;
+const videoId = id?.match(/(?:v=|youtu\.be\/)([^&]+)/)?.[1] ?? id;
+// <iframe src={`https://youtube-nocookie.com/embed/${videoId}`} ... />
+```
+
+### Options API → Plugin KV
+
+WordPress's `get_option`/`update_option` maps to the plugin KV store. The key difference: WordPress options are global, EmDash KV is automatically scoped to the plugin.
+
+```typescript
+// WordPress
+$count = get_option("myplugin_post_count", 0);
+update_option("myplugin_post_count", $count + 1);
+delete_option("myplugin_temp_data");
+
+// EmDash — no prefix needed, automatically scoped
+const count = (await ctx.kv.get<number>("post-count")) ?? 0;
+await ctx.kv.set("post-count", count + 1);
+await ctx.kv.delete("temp-data");
+```
+
+### Custom Database Tables → Storage Collections
+
+WordPress plugins that create custom tables with `$wpdb->query("CREATE TABLE ...")` should use EmDash's storage collections instead. No migrations needed — declare the schema in `definePlugin()` and it's automatically provisioned.
+
+```typescript
+// WordPress
+$wpdb->insert($table, ['form_id' => $id, 'data' => json_encode($data), 'created_at' => current_time('mysql')]);
+$results = $wpdb->get_results("SELECT * FROM $table WHERE form_id = '$id' ORDER BY created_at DESC LIMIT 50");
+
+// EmDash — declared in definePlugin()
+storage: {
+	submissions: {
+		indexes: ["formId", "createdAt", ["formId", "createdAt"]],
+	},
+},
+
+// In a hook or route handler
+await ctx.storage.submissions!.put(entryId, { formId, data, createdAt: new Date().toISOString() });
+const result = await ctx.storage.submissions!.query({
+	where: { formId },
+	orderBy: { createdAt: "desc" },
+	limit: 50,
+});
+```
+
+### Seeding Data (replaces starter content, theme setup)
+
+WordPress plugins that call `wp_insert_term()`, `register_nav_menu()`, or insert default content on activation should use a seed file:
+
+```json
+{
+	"version": "1",
+	"settings": { "title": "My Site", "tagline": "Welcome" },
+	"taxonomies": [
+		{
+			"name": "category",
+			"label": "Categories",
+			"hierarchical": true,
+			"collections": ["posts"],
+			"terms": [
+				{ "slug": "news", "label": "News" },
+				{ "slug": "tutorials", "label": "Tutorials" }
+			]
+		}
+	],
+	"menus": [
+		{
+			"name": "primary",
+			"label": "Primary Navigation",
+			"items": [
+				{ "type": "custom", "label": "Home", "url": "/" },
+				{ "type": "page", "ref": "about", "collection": "pages" }
+			]
+		}
+	],
+	"redirects": [
+		{ "source": "/?p=123", "destination": "/about" },
+		{ "source": "/old-contact", "destination": "/contact", "type": 301 }
+	]
+}
+```
+
+Save to `.emdash/seed.json` (or wire up via `package.json#emdash.seed`); the runtime applies it on the next first-boot when the database is empty.
+
+Use `redirects` for legacy WordPress URLs that still receive traffic after migration.
+
+### Querying Content (replaces WP_Query)
+
+```typescript
+// WordPress
+$query = new WP_Query(['post_type' => 'post', 'category_name' => 'tech', 'posts_per_page' => 10]);
+
+// EmDash — in Astro component frontmatter
+import { getEmDashCollection, getEntryTerms } from "emdash";
+const { entries } = await getEmDashCollection("posts", {
+	where: { category: "technology" },
+	limit: 10,
+});
+```
+
+### Menus (replaces wp_nav_menu)
+
+```typescript
+// WordPress
+wp_nav_menu(['theme_location' => 'primary']);
+
+// EmDash — in Astro component
+import { getMenu } from "emdash";
+const nav = await getMenu("primary");
+// nav.items[].label, nav.items[].url, nav.items[].children
+```
+
+### Widget Areas (replaces dynamic_sidebar)
+
+```typescript
+// WordPress
+dynamic_sidebar("sidebar-1");
+
+// EmDash — in Astro component
+import { getWidgetArea } from "emdash";
+const sidebar = await getWidgetArea("sidebar");
+// sidebar.widgets[].type: "content" | "menu" | "component"
+```
+
+## Red Flags (Need Human Decision)
+
+Flag these for review — they may need architectural decisions:
+
+1. **Deep WP integration** — Hooks into WP core features not in EmDash
+2. **Theme dependencies** — Assumes specific theme structure
+3. **Multisite features** — Not supported
+4. **Complex WP_Query** — Meta queries may need custom implementation
+5. **Direct SQL** — Schema differs, use Kysely or plugin storage
+6. **Session/transient abuse** — Needs proper caching layer
+7. **User capability checks** — Review role mapping (future)
+8. **ob_start() buffering** — PHP pattern, rethink for streaming
+9. **Cron jobs** — `wp_schedule_event()` has no direct equivalent; needs platform cron
+
+## Output Format
+
+When porting a plugin, provide:
+
+1. **Analysis** — What the WP plugin does (concepts, not code)
+2. **Concept mapping** — Which WP concepts map to which EmDash features
+3. **Plugin code** — `src/descriptor.ts` and `src/index.ts` (use **creating-plugins** skill for structure)
+4. **Seed data** — If plugin needs default taxonomies/menus/widgets
+5. **Astro components** — For frontend output
+6. **Flags** — Anything needing human decision


### PR DESCRIPTION
## 概要

EmDashスキル群を `@emdash-cms/blocks@0.7.0` から `@emdash-cms/plugin-forms@0.2.1` へ更新しました。あわせて、WordPressプラグインをEmDashへ移植するための新スキル `wordpress-plugin-to-emdash` を追加しています。

## 変更内容

- `building-emdash-site`、`creating-plugins`、`emdash-cli` スキルのメタデータ（`github-ref`、`github-tree-sha`）を最新タグへ更新
- ケイパビリティ名の変更: `read:content` → `content:read`、`network:fetch` → `network:request`
- `emdash-cli` スキルのDB初期化ドキュメントを更新（`init`/`seed` の明示的な実行が不要になった旨を反映）
- フィールド型の一覧を拡張（`select`、`multiSelect`、`file`、`slug`、`url` を追加）
- シード検証コマンド (`--validate`) の記述を削除
- `wordpress-plugin-to-emdash` スキルを新規追加（コンセプトマッピング表、移植パターン、サンプルコードを含む）

## 変更理由

上流のEmDash CMSがAPI変更と新機能追加を含む新バージョンをリリースしたため、スキルの参照内容を最新の実装に追従させる必要があった。また、WordPress移行ユースケースへの対応として新スキルを追加した。

## 技術的詳細

- スキルのメタデータは上流リポジトリの特定コミット (`github-tree-sha`) を指しており、今回は `plugin-forms@0.2.1` タグのSHAへ差し替え
- `.agents/skills/` と `.claude/skills/` の両ディレクトリは同一内容のミラーで、両方を同時に更新
- 新スキル `wordpress-plugin-to-emdash` は WordPress の各概念（カスタム投稿タイプ、タクソノミー、ウィジェット、フック等）と EmDash の対応APIをテーブル形式でマッピング

## 影響範囲

- 影響を受ける機能: `building-emdash-site`・`creating-plugins`・`emdash-cli` スキル、新規 `wordpress-plugin-to-emdash` スキル
- 影響を受けるファイル: `.agents/skills/` および `.claude/skills/` 配下の各 `SKILL.md` と参照ドキュメント
- 破壊的変更: なし（スキルドキュメントのみの変更）

## テスト方法

1. 変更後のスキルをClaudeセッションで呼び出し、内容が正しく参照されることを確認
2. `wordpress-plugin-to-emdash` スキルを `/wordpress-plugin-to-emdash` で呼び出し、コンセプトマッピング表が表示されることを確認

## チェックリスト

- [x] コードは正常に動作することを確認した
- [x] 適切なテストを追加/更新した
- [x] ドキュメントを更新した(必要な場合)
- [x] LintやFormatterを実行した
- [ ] 破壊的変更がある場合は明記した
